### PR TITLE
[#32] Migrate Rest Assured to RestTestClient

### DIFF
--- a/be/common/src/main/java/com/flix/common/util/SecurityUtils.java
+++ b/be/common/src/main/java/com/flix/common/util/SecurityUtils.java
@@ -16,6 +16,7 @@ public class SecurityUtils {
     }
 
     public static Long getCurrentUserId(Jwt jwt) {
+        log.debug("Extracting user ID from JWT: {}", jwt);
         return jwt.getClaim(USER_ID);
     }
 

--- a/be/flix-integration-test/pom.xml
+++ b/be/flix-integration-test/pom.xml
@@ -65,7 +65,33 @@
             <artifactId>spock-spring</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-restclient-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webclient</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/be/flix-integration-test/src/test/groovy/com/flix/flixintegrationtest/common/BaseITSpec.groovy
+++ b/be/flix-integration-test/src/test/groovy/com/flix/flixintegrationtest/common/BaseITSpec.groovy
@@ -1,31 +1,37 @@
 package com.flix.flixintegrationtest.common
 
 import com.flix.app.FlixPlaftformApplication
+import com.flix.common.dto.ApiResponse
 import com.flix.common.enums.Role
-import com.flix.identity.entity.User
+import com.flix.identity.common.enums.AuthProvider
 import com.flix.identity.dao.UserRepository
+import com.flix.identity.entity.User
 import io.restassured.RestAssured
 import io.restassured.builder.RequestSpecBuilder
 import io.restassured.http.ContentType
-import lombok.extern.slf4j.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.context.annotation.Import
+import org.springframework.http.ProblemDetail
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.client.EntityExchangeResult
+import org.springframework.test.web.servlet.client.RestTestClient
 import spock.lang.Specification
 
 @SpringBootTest(
-        classes = FlixPlaftformApplication,
+        classes = FlixPlaftformApplication.class,
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @Import(TestcontainersConfiguration.class)
 @ActiveProfiles("test")
+@AutoConfigureRestTestClient
 abstract class BaseITSpec extends Specification {
 
     @LocalServerPort
-    int port;
+    int port
 
     @Autowired
     JdbcTemplate jdbc;
@@ -33,14 +39,92 @@ abstract class BaseITSpec extends Specification {
     @Autowired
     UserRepository userRepository;
 
-    def setup() {
+    @Autowired
+    RestTestClient client;
+
+    protected String BASE_API;
+
+    void setup() {
         RestAssured.port = port
         RestAssured.baseURI = "http://localhost"
         RestAssured.basePath = "/v1"
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .build()
+        BASE_API = "http://localhost:${port}/v1"
     }
+
+    protected getApiResponse(String endpoint, String token) {
+        if (token != null) {
+            return client.get()
+                    .uri(BASE_API + endpoint)
+                    .header("Authorization", "Bearer ${token}")
+                    .exchange()
+        } else {
+            return client.get()
+                    .uri(BASE_API + endpoint)
+                    .exchange()
+        }
+    }
+
+    protected postRequest(String endpoint, Map body, String token = null) {
+        if (token != null) {
+            return client.post()
+                    .uri(BASE_API + endpoint)
+                    .header("Authorization", "Bearer ${token}")
+                    .body(body)
+                    .exchange()
+        } else {
+            return client.post()
+                    .uri(BASE_API + endpoint)
+                    .body(body)
+                    .exchange()
+        }
+    }
+
+    protected putRequest(String endpoint, Map body, String token = null) {
+        if (token != null) {
+            return client.put()
+                    .uri(BASE_API + endpoint)
+                    .header("Authorization", "Bearer ${token}")
+                    .body(body)
+                    .exchange()
+        } else {
+            return client.put()
+                    .uri(BASE_API + endpoint)
+                    .body(body)
+                    .exchange()
+        }
+    }
+
+    protected deleteRequest(String endpoint, String token = null) {
+        if (token != null) {
+            return client.delete()
+                    .uri(BASE_API + endpoint)
+                    .header("Authorization", "Bearer ${token}")
+                    .exchange()
+        } else {
+            return client.delete()
+                    .uri(BASE_API + endpoint)
+                    .exchange()
+        }
+    }
+
+    protected patchRequest(String endpoint, Map body, String token = null) {
+        if (token != null) {
+            return client.patch()
+                    .uri(BASE_API + endpoint)
+                    .header("Authorization", "Bearer ${token}")
+                    .body(body)
+                    .exchange()
+        } else {
+            return client.patch()
+                    .uri(BASE_API + endpoint)
+                    .body(body)
+                    .exchange()
+        }
+    }
+
 
     def cleanup() {
         def tables = jdbc.queryForList("""
@@ -56,7 +140,6 @@ abstract class BaseITSpec extends Specification {
 
     protected String loginAndGetToken(String username, String password) {
         def resp = RestAssured.given()
-                .basePath("/v1")
                 .body([username: username, password: password])
                 .post("/auth/login").body().jsonPath()
         resp.getString("data.accessToken")
@@ -72,8 +155,10 @@ abstract class BaseITSpec extends Specification {
                 isVerified: true,
         )
         user.roles.add(Role.ADMIN)
+        user.authProviders.add(AuthProvider.LOCAL)
         userRepository.save(user)
     }
+
 
     protected User createNormalUser() {
         def passwordEncode = '$2a$12$pmIXxQ7H.iNsd6BrXRbC/..DoMMuuFEfKml33imgyOuZklipEtpZ.'
@@ -85,14 +170,17 @@ abstract class BaseITSpec extends Specification {
                 isVerified: true,
         )
         user.roles.add(Role.USER)
+        user.authProviders.add(AuthProvider.LOCAL)
         userRepository.save(user)
     }
 
     protected String getAdminToken() {
-        loginAndGetToken("admin", "Admin@123")
+        return loginAndGetToken("admin", "Admin@123")
     }
 
     protected String getNormalUserToken() {
-        loginAndGetToken("testNormalUser", "Admin@123")
+        return loginAndGetToken("testNormalUser", "Admin@123")
     }
+
+
 }

--- a/be/flix-integration-test/src/test/groovy/com/flix/flixintegrationtest/identity/api/auth/AuthIT.groovy
+++ b/be/flix-integration-test/src/test/groovy/com/flix/flixintegrationtest/identity/api/auth/AuthIT.groovy
@@ -1,10 +1,12 @@
 package com.flix.flixintegrationtest.identity.api.auth
 
+import com.flix.common.dto.ApiResponse
 import com.flix.common.enums.Role
 import com.flix.flixintegrationtest.common.BaseITSpec
 import com.flix.flixintegrationtest.identity.config.BaseIT
 import io.restassured.RestAssured
 import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
 class AuthIT extends BaseITSpec {
 
@@ -25,14 +27,16 @@ class AuthIT extends BaseITSpec {
     }
 
     def "should fail login with invalid credentials"() {
-        when:
-        def response = RestAssured.given()
-                .body([username: "asdasd", password: "asdasd"])
-                .post(BaseIT.LOGIN_API)
-        then:
-        response.statusCode() == 401
-        response.body().jsonPath().getString("detail").equalsIgnoreCase("Invalid username or password")
+        given:
+        def invalidUserCredential = [username: "asdasd", password: "asdasd"]
 
+        when:
+        def resp = postRequest(BaseIT.LOGIN_API, invalidUserCredential)
+                .returnResult(ProblemDetail)
+
+        then:
+        resp.status == HttpStatus.UNAUTHORIZED
+        resp.responseBody.detail == "Invalid username or password"
     }
 
     //Register Tests
@@ -84,6 +88,21 @@ class AuthIT extends BaseITSpec {
         "missing username"     | [username: "", email: "asdasda@gmail.com", password: "123"]
         "missing email"        | [username: "test", email: "", password: "123"]
         "missing password"     | [username: "test", email: "asdasda@gmail.com", password: ""]
+    }
+
+    def "should return true when provider is local"() {
+        given:
+        createNormalUser()
+        String token = getNormalUserToken()
+
+        when:
+        def resp = getApiResponse(BaseIT.IS_LOCAL_PROVIDER, token)
+                .returnResult(ApiResponse)
+
+        then:
+        resp.status == HttpStatus.OK
+        resp.responseBody.data == true
+
     }
 
 

--- a/be/flix-integration-test/src/test/groovy/com/flix/flixintegrationtest/identity/config/BaseIT.java
+++ b/be/flix-integration-test/src/test/groovy/com/flix/flixintegrationtest/identity/config/BaseIT.java
@@ -4,6 +4,6 @@ public class BaseIT {
     public static final String LOGIN_API = "/auth/login";
     public static final String REGISTER_NORMAL_API = "/auth/register/normal";
     public static final String REGISTER_VIP_API = "/auth/register/vip";
+    public static final String IS_LOCAL_PROVIDER = "/auth/is-local-provider";
     public static final String PROFILE_API = "/profile";
-
 }

--- a/be/identity/pom.xml
+++ b/be/identity/pom.xml
@@ -64,6 +64,12 @@
             <artifactId>tomcat-embed-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <properties>

--- a/be/identity/src/main/java/com/flix/identity/api/AuthController.java
+++ b/be/identity/src/main/java/com/flix/identity/api/AuthController.java
@@ -1,6 +1,7 @@
 package com.flix.identity.api;
 
 import com.flix.common.dto.ApiResponse;
+import com.flix.common.util.SecurityUtils;
 import com.flix.identity.common.dto.AuthResponse;
 import com.flix.identity.common.dto.LoginRequest;
 import com.flix.identity.common.dto.RegisterRequest;
@@ -10,6 +11,8 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -39,4 +42,14 @@ public class AuthController {
         var authResponse = authService.login(request);
         return ApiResponse.success(authResponse);
     }
+
+    @GetMapping("/is-local-provider")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<Boolean> checkProvider(
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+       Long userId = SecurityUtils.getCurrentUserId(jwt);
+       return ApiResponse.success(authService.checkProvider(userId));
+    }
+
 }

--- a/be/identity/src/main/java/com/flix/identity/auth/service/AuthService.java
+++ b/be/identity/src/main/java/com/flix/identity/auth/service/AuthService.java
@@ -130,4 +130,14 @@ public class AuthService {
         return generateToken(user.getId(), user.getUsername(), roles);
     }
 
+    public boolean checkProvider(Long userId) {
+        log.info("Checking if local provider for user {}", userId);
+        boolean isLocal = userRepository.findById(userId)
+                .map(user -> user.getAuthProviders().contains(AuthProvider.LOCAL))
+                .orElse(false);
+        log.debug("Local provider for user {} is {}", userId, isLocal);
+
+        return isLocal;
+    }
+
 }

--- a/be/identity/src/test/java/com/flix/identity/service/CustomOidcUserServiceTest.java
+++ b/be/identity/src/test/java/com/flix/identity/service/CustomOidcUserServiceTest.java
@@ -2,8 +2,8 @@ package com.flix.identity.service;
 
 import com.flix.common.enums.Role;
 import com.flix.identity.auth.service.CustomOidcUserService;
+import com.flix.identity.common.enums.AuthProvider;
 import com.flix.identity.entity.User;
-import com.flix.identity.auth.enums.AuthProvider;
 import com.flix.identity.dao.UserProfileRepository;
 import com.flix.identity.dao.UserRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/be/pom.xml
+++ b/be/pom.xml
@@ -44,11 +44,6 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
         </dependency>
 
@@ -123,6 +118,7 @@
                 <version>${restassured.version}</version>
                 <scope>test</scope>
             </dependency>
+
 
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Closes #32 

feat: add endpoint to check if user is local provider
This pull request introduces a new API endpoint to check if a user has the local authentication provider, improves integration test utilities for REST API testing, and updates dependencies to support these changes. The most important changes are grouped below by theme.

### New Feature: Local Provider Check

* Added a new `/auth/is-local-provider` endpoint in `AuthController` that returns whether the authenticated user has the local auth provider, using a new `checkProvider` method in `AuthService` and extracting the user ID from the JWT (`AuthController.java`, `AuthService.java`, `SecurityUtils.java`, `BaseIT.java`) [[1]](diffhunk://#diff-a7e04f0778b63b870e4f4857a3071c95e836991eaa2876fe6b3b3f70e7fb90b6R45-R54) [[2]](diffhunk://#diff-a2878bf5ddff1469c153e7d002de6546b3a89c2be64ab61cc5e71223eacedd19R133-R142) [[3]](diffhunk://#diff-0d93d192472ea60cf8c5044c83a64aeb83a773c958a1d5376b498bca82657991R7-L8) [[4]](diffhunk://#diff-408a14a923496867bacd6af6dda85fbefc28517d2cda8744cd8d3392b77c5e00R19).

### Integration Test Enhancements

* Refactored `BaseITSpec` to use `RestTestClient` for HTTP requests, added helper methods for common HTTP verbs, and improved token handling and user creation for tests (`BaseITSpec.groovy`) [[1]](diffhunk://#diff-9d7e239879ecd5c51a98c193e1c02e1ff1cf64b469f518a9f5a34149519e7bb2R4-R128) [[2]](diffhunk://#diff-9d7e239879ecd5c51a98c193e1c02e1ff1cf64b469f518a9f5a34149519e7bb2L59) [[3]](diffhunk://#diff-9d7e239879ecd5c51a98c193e1c02e1ff1cf64b469f518a9f5a34149519e7bb2R158-R162) [[4]](diffhunk://#diff-9d7e239879ecd5c51a98c193e1c02e1ff1cf64b469f518a9f5a34149519e7bb2R173-R185).
* Updated `AuthIT.groovy` tests to use the new helpers and added a test for the new local provider endpoint (`AuthIT.groovy`) [[1]](diffhunk://#diff-7b402f60e430ca49d20d0eb98402b4d0f01ba07de2761cc940d842e3ef732713R3-R9) [[2]](diffhunk://#diff-7b402f60e430ca49d20d0eb98402b4d0f01ba07de2761cc940d842e3ef732713R30-R39) [[3]](diffhunk://#diff-7b402f60e430ca49d20d0eb98402b4d0f01ba07de2761cc940d842e3ef732713R93-R107).

### Dependency Updates

* Added necessary Spring Boot test and web dependencies to `identity` and `flix-integration-test` modules to support new testing utilities and REST client usage (`pom.xml` files) [[1]](diffhunk://#diff-e2a29bf094a731681b13cf53e23b6b99c24f25c72966f297bec766d73929604eR68-R94) [[2]](diffhunk://#diff-9d9116efa6a6b6fb23581922578f6e1a23edb11dac6ffa79ddfa9ba53f5b3da9R67-R72).
* Minor dependency cleanup in the parent POM (`be/pom.xml`) [[1]](diffhunk://#diff-8463ff49806ad86bdd03dcbc1e7b7009773300ba2cce38a58636c7d4423a3362L45-L49) [[2]](diffhunk://#diff-8463ff49806ad86bdd03dcbc1e7b7009773300ba2cce38a58636c7d4423a3362R122).

### Code Consistency

* Ensured usage of the correct `AuthProvider` enum import in test files (`CustomOidcUserServiceTest.java`).

These changes collectively improve the authentication API and make integration testing more robust and maintainable.