### PR TITLE
[#55] Implement Phase 5: AI Chatbot Improvements

### DIFF
--- a/be/app/src/main/resources/application.yml
+++ b/be/app/src/main/resources/application.yml
@@ -45,4 +45,4 @@ management:
 
 # API key for chatbot
 gemini:
-  api-key: "AIzaSyD73BMaxrO1OkdbaAQVY8m22CeEEoFs37g"
+  api-key: ${GEMINI_API_KEY}

--- a/be/app/src/main/resources/application.yml
+++ b/be/app/src/main/resources/application.yml
@@ -42,3 +42,7 @@ management:
   endpoint:
     env:
       show-values: never
+
+# API key for chatbot
+gemini:
+  api-key: "AIzaSyD73BMaxrO1OkdbaAQVY8m22CeEEoFs37g"

--- a/be/catalog/src/main/java/com/flix/catalog/ai/service/AiChatService.java
+++ b/be/catalog/src/main/java/com/flix/catalog/ai/service/AiChatService.java
@@ -1,0 +1,110 @@
+package com.flix.catalog.ai.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flix.catalog.common.dto.AiChatRequest;
+import com.flix.catalog.common.dto.AiChatResponse;
+import com.flix.catalog.entity.ProductEntity;
+import com.flix.catalog.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiChatService {
+
+    private final ProductService productService;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${gemini.api-key:}")
+    private String geminiApiKey;
+
+    public AiChatResponse getChatResponse(AiChatRequest request) {
+        if (geminiApiKey == null || geminiApiKey.isEmpty()) {
+            log.warn("Gemini API key is not configured.");
+            return new AiChatResponse("Xin lỗi, tính năng AI hiện tại chưa được cấu hình (Thiếu API Key).");
+        }
+
+        String prompt = buildPrompt(request);
+        String url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=" + geminiApiKey;
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            Map<String, Object> textPart = new HashMap<>();
+            textPart.put("text", prompt);
+
+            Map<String, Object> partMap = new HashMap<>();
+            partMap.put("parts", List.of(textPart));
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("contents", List.of(partMap));
+
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+
+            JsonNode root = objectMapper.readTree(response.getBody());
+            String replyText = root.path("candidates").get(0)
+                                   .path("content")
+                                   .path("parts").get(0)
+                                   .path("text").asText();
+
+            return new AiChatResponse(replyText);
+
+        } catch (Exception e) {
+            log.error("Failed to call Gemini API", e);
+            return new AiChatResponse("Xin lỗi, hệ thống AI đang quá tải hoặc gặp sự cố. Vui lòng thử lại sau.");
+        }
+    }
+
+    private String buildPrompt(AiChatRequest request) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("Bạn là chuyên gia tư vấn môi trường (Carbon Advisor) của hệ thống thương mại điện tử GreenLife Eco-Commerce. ");
+        prompt.append("Nhiệm vụ của bạn là giải đáp ngắn gọn, dễ hiểu và thân thiện về các chỉ số tác động môi trường của sản phẩm cho khách hàng.\n\n");
+
+        if (request.getProductId() != null) {
+            try {
+                var productResponse = productService.getProductDetail(request.getProductId());
+                prompt.append("Khách hàng đang hỏi về sản phẩm: '").append(productResponse.name()).append("'.\n");
+                prompt.append("Thông tin môi trường của sản phẩm này:\n");
+                prompt.append("- Chỉ số Carbon (Lượng CO2 phát thải): ").append(productResponse.carbonIndex()).append(" kg CO2/đơn vị.\n");
+                prompt.append("- Xếp hạng thân thiện (Eco-friendliness): ").append(productResponse.ecoFriendliness()).append(".\n");
+                prompt.append("- Điểm xanh tích luỹ khi mua (Green points): ").append(productResponse.greenPoints()).append(" điểm.\n");
+                if (productResponse.materials() != null && !productResponse.materials().isEmpty()) {
+                    prompt.append("- Vật liệu: ");
+                    productResponse.materials().forEach(m -> prompt.append(m.name()).append(", "));
+                    prompt.append("\n");
+                }
+                if (productResponse.greenCertificates() != null && !productResponse.greenCertificates().isEmpty()) {
+                    prompt.append("- Chứng chỉ xanh: ");
+                    productResponse.greenCertificates().forEach(c -> prompt.append(c.name()).append(", "));
+                    prompt.append("\n");
+                }
+            } catch (Exception e) {
+                log.warn("Could not fetch product for AI prompt, id: {}", request.getProductId(), e);
+            }
+        }
+
+        prompt.append("\nCâu hỏi của khách hàng: \"").append(request.getMessage()).append("\"\n\n");
+        prompt.append("Yêu cầu trả lời:\n");
+        prompt.append("- Trả lời trực tiếp vào câu hỏi.\n");
+        prompt.append("- Tư vấn rõ ý nghĩa của con số CO2 (cao hay thấp, tác động thế nào).\n");
+        prompt.append("- Không dùng định dạng quá phức tạp, giữ tông giọng thân thiện, tự nhiên.");
+
+        return prompt.toString();
+    }
+}

--- a/be/catalog/src/main/java/com/flix/catalog/ai/service/AiChatService.java
+++ b/be/catalog/src/main/java/com/flix/catalog/ai/service/AiChatService.java
@@ -39,35 +39,49 @@ public class AiChatService {
         }
 
         String prompt = buildPrompt(request);
-        String url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=" + geminiApiKey;
+        String url = "https://generativelanguage.googleapis.com/v1beta/interactions";
 
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
-
-            Map<String, Object> textPart = new HashMap<>();
-            textPart.put("text", prompt);
-
-            Map<String, Object> partMap = new HashMap<>();
-            partMap.put("parts", List.of(textPart));
+            headers.set("x-goog-api-key", geminiApiKey);
 
             Map<String, Object> body = new HashMap<>();
-            body.put("contents", List.of(partMap));
+            body.put("model", "gemini-3.6-flash");
+            body.put("input", prompt);
 
             HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
             ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
 
             JsonNode root = objectMapper.readTree(response.getBody());
-            String replyText = root.path("candidates").get(0)
-                                   .path("content")
-                                   .path("parts").get(0)
-                                   .path("text").asText();
-
-            return new AiChatResponse(replyText);
+            String replyText = "";
+            try {
+                for (JsonNode step : root.path("steps")) {
+                    if ("model_output".equals(step.path("type").asText())) {
+                        for (JsonNode content : step.path("content")) {
+                            if ("text".equals(content.path("type").asText())) {
+                                replyText = content.path("text").asText();
+                                break;
+                            }
+                        }
+                    }
+                    if (!replyText.isEmpty()) break;
+                }
+                if (replyText.isEmpty()) {
+                    return new AiChatResponse("Parse error (no text found). Raw JSON: " + response.getBody());
+                }
+                return new AiChatResponse(replyText);
+            } catch (Exception e) {
+                return new AiChatResponse("Parse error. Raw JSON: " + response.getBody());
+            }
 
         } catch (Exception e) {
             log.error("Failed to call Gemini API", e);
-            return new AiChatResponse("Xin lỗi, hệ thống AI đang quá tải hoặc gặp sự cố. Vui lòng thử lại sau.");
+            String errorMsg = e.getMessage();
+            if (e instanceof org.springframework.web.client.HttpStatusCodeException httpEx) {
+                errorMsg = httpEx.getResponseBodyAsString();
+            }
+            return new AiChatResponse("Lỗi API Gemini: " + errorMsg);
         }
     }
 
@@ -76,11 +90,22 @@ public class AiChatService {
         prompt.append("Bạn là chuyên gia tư vấn môi trường (Carbon Advisor) của hệ thống thương mại điện tử GreenLife Eco-Commerce. ");
         prompt.append("Nhiệm vụ của bạn là giải đáp ngắn gọn, dễ hiểu và thân thiện về các chỉ số tác động môi trường của sản phẩm cho khách hàng.\n\n");
 
+        prompt.append("Dưới đây là Danh mục tham khảo nhanh các sản phẩm trong hệ thống GreenLife (Dùng để trả lời nếu khách hàng so sánh hoặc hỏi về sản phẩm khác):\n");
+        try {
+            var products = productService.listProducts(org.springframework.data.domain.PageRequest.of(0, 50)).getContent();
+            for (var p : products) {
+                prompt.append(String.format("- %s: %s kg CO2, %s điểm xanh, Rank: %s\n", p.name(), p.carbonIndex(), p.greenPoints(), p.ecoFriendliness()));
+            }
+            prompt.append("\n");
+        } catch (Exception e) {
+            log.warn("Could not fetch product list for AI prompt", e);
+        }
+
         if (request.getProductId() != null) {
             try {
                 var productResponse = productService.getProductDetail(request.getProductId());
-                prompt.append("Khách hàng đang hỏi về sản phẩm: '").append(productResponse.name()).append("'.\n");
-                prompt.append("Thông tin môi trường của sản phẩm này:\n");
+                prompt.append("Khách hàng đang xem chi tiết sản phẩm: '").append(productResponse.name()).append("'.\n");
+                prompt.append("Thông tin môi trường đầy đủ của sản phẩm này:\n");
                 prompt.append("- Chỉ số Carbon (Lượng CO2 phát thải): ").append(productResponse.carbonIndex()).append(" kg CO2/đơn vị.\n");
                 prompt.append("- Xếp hạng thân thiện (Eco-friendliness): ").append(productResponse.ecoFriendliness()).append(".\n");
                 prompt.append("- Điểm xanh tích luỹ khi mua (Green points): ").append(productResponse.greenPoints()).append(" điểm.\n");
@@ -103,6 +128,7 @@ public class AiChatService {
         prompt.append("Yêu cầu trả lời:\n");
         prompt.append("- Trả lời trực tiếp vào câu hỏi.\n");
         prompt.append("- Tư vấn rõ ý nghĩa của con số CO2 (cao hay thấp, tác động thế nào).\n");
+        prompt.append("- Dựa vào danh mục hệ thống để so sánh nếu cần thiết.\n");
         prompt.append("- Không dùng định dạng quá phức tạp, giữ tông giọng thân thiện, tự nhiên.");
 
         return prompt.toString();

--- a/be/catalog/src/main/java/com/flix/catalog/api/controller/AiChatController.java
+++ b/be/catalog/src/main/java/com/flix/catalog/api/controller/AiChatController.java
@@ -1,0 +1,26 @@
+package com.flix.catalog.api.controller;
+
+import com.flix.catalog.ai.service.AiChatService;
+import com.flix.catalog.common.dto.AiChatRequest;
+import com.flix.catalog.common.dto.AiChatResponse;
+import com.flix.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/ai/chat")
+@RequiredArgsConstructor
+public class AiChatController {
+
+    private final AiChatService aiChatService;
+
+    @PostMapping("/carbon-advisor")
+    public ResponseEntity<ApiResponse<AiChatResponse>> chatWithAI(@RequestBody AiChatRequest request) {
+        AiChatResponse response = aiChatService.getChatResponse(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/be/catalog/src/main/java/com/flix/catalog/common/dto/AiChatRequest.java
+++ b/be/catalog/src/main/java/com/flix/catalog/common/dto/AiChatRequest.java
@@ -1,0 +1,13 @@
+package com.flix.catalog.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiChatRequest {
+    private String message;
+    private Long productId;
+}

--- a/be/catalog/src/main/java/com/flix/catalog/common/dto/AiChatResponse.java
+++ b/be/catalog/src/main/java/com/flix/catalog/common/dto/AiChatResponse.java
@@ -1,0 +1,12 @@
+package com.flix.catalog.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiChatResponse {
+    private String reply;
+}

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-toggle": "1.1.2",
         "@radix-ui/react-toggle-group": "1.1.2",
         "@radix-ui/react-tooltip": "1.1.8",
+        "@stomp/stompjs": "^7.3.0",
         "axios": "^1.19.0",
         "browser-image-compression": "^2.0.2",
         "canvas-confetti": "1.9.4",
@@ -2977,6 +2978,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.12",

--- a/fe/package.json
+++ b/fe/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-toggle": "1.1.2",
     "@radix-ui/react-toggle-group": "1.1.2",
     "@radix-ui/react-tooltip": "1.1.8",
+    "@stomp/stompjs": "^7.3.0",
     "axios": "^1.19.0",
     "browser-image-compression": "^2.0.2",
     "canvas-confetti": "1.9.4",

--- a/fe/src/api/chat.ts
+++ b/fe/src/api/chat.ts
@@ -18,8 +18,10 @@ export const chatWithAi = async (data: AiChatRequest): Promise<AiChatResponse> =
 export interface Conversation {
   id: number;
   userId: number;
-  adminId?: number;
-  status: string;
+  type: string;
+  user1Id: number;
+  user2Id: number;
+  isDeleted: boolean;
 }
 
 export interface ChatMessage {
@@ -31,19 +33,42 @@ export interface ChatMessage {
   createdAt: string;
 }
 
-export const createOrGetConversation = async (): Promise<Conversation> => {
-  const response = await client.post('/v1/conversation');
+export const getUserConversations = async (userId: number): Promise<Conversation[]> => {
+  const response = await client.get(`/v1/conversation/user/${userId}`);
   return response.data.data;
 };
 
-export const getMessagesByConversation = async (conversationId: number): Promise<ChatMessage[]> => {
-  const response = await client.get(`/v1/message/conversation/${conversationId}`);
+export const createOrGetConversation = async (userId: number): Promise<Conversation> => {
+  try {
+    const list = await getUserConversations(userId);
+    if (list && list.length > 0) {
+      return list[0];
+    }
+  } catch (e) {
+    console.error("Error fetching conversations", e);
+  }
+
+  const response = await client.post('/v1/conversation', {
+    type: 'USER',
+    user1Id: userId,
+    user2Id: 1, 
+    isDeleted: false
+  });
+  return response.data.data;
+};
+
+export const getMessagesByConversation = async (conversationId: number, userId: number): Promise<ChatMessage[]> => {
+  const response = await client.get(`/v1/message/conversation/${conversationId}`, {
+    headers: { userId }
+  });
   return response.data.data;
 };
 
 export interface SendMessageRequest {
   conversationId: number;
   content: string;
+  senderId: number;
+  fileUrl?: string;
 }
 
 export const sendMessage = async (data: SendMessageRequest): Promise<ChatMessage> => {

--- a/fe/src/api/chat.ts
+++ b/fe/src/api/chat.ts
@@ -1,0 +1,42 @@
+import client from './client';
+
+export interface AiChatRequest {
+  message: string;
+  productId?: number;
+}
+
+export interface AiChatResponse {
+  reply: string;
+}
+
+export const chatWithAi = async (data: AiChatRequest): Promise<AiChatResponse> => {
+  const response = await client.post('/v1/ai/chat/carbon-advisor', data);
+  return response.data.data; // ApiResponse.data
+};
+
+// Types for Live Chat (Team has already done BE, this is just calling the API)
+export interface Conversation {
+  id: number;
+  userId: number;
+  adminId?: number;
+  status: string;
+}
+
+export interface ChatMessage {
+  id: number;
+  conversationId: number;
+  senderId: number;
+  content: string;
+  fileUrl?: string;
+  createdAt: string;
+}
+
+export const createOrGetConversation = async (): Promise<Conversation> => {
+  const response = await client.post('/v1/conversation');
+  return response.data.data;
+};
+
+export const getMessagesByConversation = async (conversationId: number): Promise<ChatMessage[]> => {
+  const response = await client.get(`/v1/message/conversation/${conversationId}`);
+  return response.data.data;
+};

--- a/fe/src/api/chat.ts
+++ b/fe/src/api/chat.ts
@@ -40,3 +40,13 @@ export const getMessagesByConversation = async (conversationId: number): Promise
   const response = await client.get(`/v1/message/conversation/${conversationId}`);
   return response.data.data;
 };
+
+export interface SendMessageRequest {
+  conversationId: number;
+  content: string;
+}
+
+export const sendMessage = async (data: SendMessageRequest): Promise<ChatMessage> => {
+  const response = await client.post('/v1/message', data);
+  return response.data.data;
+};

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -21,7 +21,7 @@ import imgThumb1 from "../imports/ProductDetail2/216f26d6776c3bc25b08f4a2fc1a937
 import imgThumb2 from "../imports/ProductDetail2/500cb84cb3311510ee21f4b4f07293aa58527802.png";
 import imgThumb3 from "../imports/ProductDetail2/d676d1e4513ae183577337dd633cacf4df304944.png";
 import imgThumb4 from "../imports/ProductDetail2/45e21f35a448272b3d6c4d80ab24fd03cfec6002.png";
-import { AIChatbot } from "./components/AIChatbot";
+import { AIChatbot, ChatbotIntent } from "./components/AIChatbot";
 import { ProfilePage } from "./components/ProfilePage";
 import { SignUpPage } from "./components/SignUpPage";
 import { SignInPage } from "./components/SignInPage";
@@ -889,7 +889,10 @@ export default function App() {
   const [activePage, setActivePage] = useState<Page>(() => {
     return (sessionStorage.getItem("activePage") as Page) || "home";
   });
-  const [activeProductId, setActiveProductId] = useState<number | null>(null);
+  const [activeProductId, setActiveProductId] = useState<number | null>(() => {
+    const saved = sessionStorage.getItem("activeProductId");
+    return saved ? parseInt(saved) : null;
+  });
   const [searchOpen, setSearchOpen] = useState(false);
   const [activeShopCategory, setActiveShopCategory] = useState("All");
   const [globalSearchTerm, setGlobalSearchTerm] = useState("");
@@ -948,7 +951,10 @@ export default function App() {
   }, [fetchCart]);
 
   // Chatbot control — increment a counter so useEffect in AIChatbot fires each time
-  const [chatbotTrigger, setChatbotTrigger] = useState(0);
+  const [chatIntent, setChatIntent] = useState<ChatbotIntent>({ triggerId: 0 });
+  const openChatbot = (options?: Omit<ChatbotIntent, "triggerId">) => {
+    setChatIntent(prev => ({ triggerId: prev.triggerId + 1, ...options }));
+  };
 
   const setToken = useAuthStore(state => state.setToken);
 
@@ -973,7 +979,10 @@ export default function App() {
   const navigate = (page: Page, productId?: number, category?: string, searchTerm?: string, extraFilters?: { carbon?: string, certs?: string[] }) => {
     sessionStorage.setItem("activePage", page);
     setActivePage(page);
-    if (productId !== undefined) setActiveProductId(productId);
+    if (productId !== undefined) {
+      setActiveProductId(productId);
+      sessionStorage.setItem("activeProductId", productId.toString());
+    }
     
     if (page === "shop") {
       setActiveShopCategory(category !== undefined ? category : "All");
@@ -988,9 +997,7 @@ export default function App() {
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
-  const openChatbot = () => {
-    setChatbotTrigger((n) => n + 1);
-  };
+
 
   // Cart helpers
   const handleAddToCart = async (product: Product, quantity = 1) => {
@@ -1142,7 +1149,7 @@ export default function App() {
 
       <Footer />
       <BottomNav activePage={activePage} onNavigate={navigate} onOpenChatbot={openChatbot} />
-      <AIChatbot openTrigger={chatbotTrigger} />
+      <AIChatbot chatIntent={chatIntent} activeProductId={activeProductId} />
     </div>
   );
 }

--- a/fe/src/app/components/AIChatbot.tsx
+++ b/fe/src/app/components/AIChatbot.tsx
@@ -1,15 +1,18 @@
 import { useState, useRef, useEffect } from "react";
-import { X, RefreshCw, Send, Leaf, Minus, Headphones } from "lucide-react";
+import { X, RefreshCw, Send, Leaf, Minus, Headphones, Image as ImageIcon, Loader2 } from "lucide-react";
 import svgPaths from "../../imports/ProductDetail2/svg-oqupvr7hg1";
 import { chatWithAi, createOrGetConversation, getMessagesByConversation, sendMessage as sendLiveMessage, ChatMessage as ApiChatMessage } from "../../api/chat";
 import { Client } from "@stomp/stompjs";
 import { useAuthStore } from "../../store/authStore";
+import imageCompression from 'browser-image-compression';
+import { profileApi } from "../../api/profile";
 
 interface Message {
   id: string;
   role: "bot" | "user" | "admin";
   content: string;
   time?: string;
+  fileUrl?: string;
 }
 
 // ─── AI tab data ─────────────────────────────────────────────────────────────
@@ -38,35 +41,108 @@ const INITIAL_ADMIN: Message[] = [
   { id: "adm-2", role: "admin", content: "Em có thể hỗ trợ Anh/Chị về đơn hàng, đổi trả, hoặc bất kỳ thắc mắc nào khác. Anh/Chị cần giúp gì ạ?", time: now() },
 ];
 
+const renderMarkdown = (text: string) => {
+  return text.split('\n').map((line, i) => {
+    const trimmed = line.trim();
+    if (trimmed === '---') {
+      return <hr key={i} className="my-3 border-t border-[#e2e3de]" />;
+    }
+
+    let isHeading = false;
+    let isBullet = false;
+    let lineContent = line;
+
+    if (trimmed.startsWith('### ')) {
+      isHeading = true;
+      lineContent = trimmed.substring(4);
+    } else if (trimmed.startsWith('## ')) {
+      isHeading = true;
+      lineContent = trimmed.substring(3);
+    } else if (trimmed.startsWith('# ')) {
+      isHeading = true;
+      lineContent = trimmed.substring(2);
+    } else if (trimmed.match(/^(\d+\.|-|\*)\s/)) {
+      isBullet = true;
+      lineContent = trimmed.replace(/^(\d+\.|-|\*)\s/, '');
+    }
+    
+    const parsedLine = lineContent.split(/(\*\*.*?\*\*|\*.*?\*)/g).map((part, j) => {
+      if (part.startsWith('**') && part.endsWith('**')) {
+        return <strong key={j} className="font-bold">{part.slice(2, -2)}</strong>;
+      }
+      if (part.startsWith('*') && part.endsWith('*')) {
+        return <em key={j} className="italic">{part.slice(1, -1)}</em>;
+      }
+      return part;
+    });
+
+    if (isHeading) {
+      return (
+        <div key={i} className="font-bold text-[14px] mt-2 mb-1 text-[#1a1c19]">
+          {parsedLine}
+        </div>
+      );
+    }
+
+    if (isBullet) {
+      return (
+        <li key={i} className="ml-4 list-disc marker:text-[#274f4f] mt-1">
+          {parsedLine}
+        </li>
+      );
+    }
+
+    return (
+      <span key={i}>
+        {parsedLine}
+        <br />
+      </span>
+    );
+  });
+};
+
+export type ChatbotIntent = {
+  triggerId: number;
+  mode?: "ai" | "admin";
+  autoSendPrompt?: string;
+  prefillMessage?: string;
+};
+
 // ─── Component ────────────────────────────────────────────────────────────────
-export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
+export function AIChatbot({ chatIntent, activeProductId }: { chatIntent?: ChatbotIntent; activeProductId?: number | null }) {
   const [chatOpen, setChatOpen] = useState(false);
-  const [widgetVisible, setWidgetVisible] = useState(true);
   const [activeTab, setActiveTab] = useState<"ai" | "admin">("ai");
 
   const [aiMessages, setAiMessages] = useState<Message[]>(INITIAL_AI);
   const [adminMessages, setAdminMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [isTyping, setIsTyping] = useState(false);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
 
   const { user } = useAuthStore();
   const [conversationId, setConversationId] = useState<number | null>(null);
   const stompClientRef = useRef<Client | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Initialize and connect WS when switching to Admin Tab
   useEffect(() => {
     if (activeTab === "admin" && user) {
+      if (user.roles?.includes("ADMIN") || user.roles?.includes("ROLE_ADMIN")) {
+        setAdminMessages([{ id: "admin-sys", role: "admin", content: "Bạn đang đăng nhập bằng tài khoản Admin. Khung chat này dành cho khách hàng. Vui lòng đăng nhập tài khoản User để test hoặc vào Admin Dashboard.", time: now() }]);
+        return;
+      }
+
       let active = true;
-      createOrGetConversation().then(conv => {
+      createOrGetConversation(user.id).then(conv => {
         if (!active) return;
         setConversationId(conv.id);
-        getMessagesByConversation(conv.id).then(msgs => {
+        getMessagesByConversation(conv.id, user.id).then(msgs => {
           if (!active) return;
           const mapped: Message[] = msgs.map(m => ({
             id: m.id.toString(),
             role: m.senderId === user.id ? "user" : "admin",
             content: m.content,
-            time: new Date(m.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" })
+            time: new Date(m.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" }),
+            fileUrl: m.fileUrl
           }));
           setAdminMessages(mapped);
         });
@@ -78,11 +154,29 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
               const newMsg: ApiChatMessage = JSON.parse(msg.body);
               setAdminMessages(prev => {
                 if (prev.find(m => m.id === newMsg.id.toString())) return prev;
+                
+                // If the message is from us, try to replace the optimistic tmp message
+                if (newMsg.senderId === user.id) {
+                  const tmpIndex = prev.findIndex(m => m.role === "user" && m.id.length > 10 && m.content === newMsg.content);
+                  if (tmpIndex !== -1) {
+                    const copy = [...prev];
+                    copy[tmpIndex] = {
+                      id: newMsg.id.toString(),
+                      role: "user",
+                      content: newMsg.content,
+                      time: new Date(newMsg.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" }),
+                      fileUrl: newMsg.fileUrl
+                    };
+                    return copy;
+                  }
+                }
+
                 return [...prev, {
                   id: newMsg.id.toString(),
                   role: newMsg.senderId === user.id ? "user" : "admin",
                   content: newMsg.content,
-                  time: new Date(newMsg.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" })
+                  time: new Date(newMsg.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" }),
+                  fileUrl: newMsg.fileUrl
                 }];
               });
             });
@@ -118,40 +212,27 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [aiMessages, adminMessages, isTyping]);
 
-  useEffect(() => {
-    if (openTrigger > 0) {
-      setChatOpen(true);
-      setWidgetVisible(false);
-    }
-  }, [openTrigger]);
+
 
   useEffect(() => {
     if (chatOpen) setTimeout(() => inputRef.current?.focus(), 100);
   }, [chatOpen, activeTab]);
 
-  const handleLearnMore = () => {
-    setWidgetVisible(false);
-    setChatOpen(true);
-    setActiveTab("ai");
-    setIsTyping(true);
-    setTimeout(() => {
-      setIsTyping(false);
-      setAiMessages((prev) => [...prev, { id: Date.now().toString(), role: "bot", content: LEARN_MORE_RESPONSE }]);
-    }, 1200);
-  };
 
-  const handleSend = async () => {
-    if (!input.trim() || isTyping) return;
-    const text = input.trim();
+
+  const handleSend = async (customText?: string, imageUrl?: string, overrideTab?: "ai" | "admin") => {
+    const text = customText !== undefined ? customText : input.trim();
+    if ((!text && !imageUrl) || isTyping) return;
+    
     const msgId = Date.now().toString();
+    const currentTab = overrideTab || activeTab;
 
-    if (activeTab === "ai") {
+    if (currentTab === "ai") {
       setAiMessages((prev) => [...prev, { id: msgId, role: "user", content: text }]);
       setInput("");
       setIsTyping(true);
 
-      const productIdStr = window.location.pathname.match(/\/product\/(\d+)/)?.[1];
-      const productId = productIdStr ? parseInt(productIdStr) : undefined;
+      const productId = activeProductId || undefined;
 
       try {
         const res = await chatWithAi({ message: text, productId });
@@ -168,20 +249,72 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
       }
       
       const tmpId = Date.now().toString();
-      setAdminMessages((prev) => [...prev, { id: tmpId, role: "user", content: text, time: now() }]);
-      setInput("");
-      setIsTyping(false); // real-time so no fake typing wait
+      setAdminMessages((prev) => [...prev, { id: tmpId, role: "user", content: text, time: now(), fileUrl: imageUrl }]);
+      if (customText === undefined) setInput("");
+      setIsTyping(false);
 
-      sendLiveMessage({ conversationId, content: text }).then((res) => {
-        setAdminMessages(prev => prev.map(m => m.id === tmpId ? {
-          id: res.id.toString(),
-          role: "user",
-          content: res.content,
-          time: new Date(res.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" })
-        } : m));
+      const sendContent = text || "[Hình ảnh]";
+
+      sendLiveMessage({ conversationId, content: sendContent, senderId: user!.id, fileUrl: imageUrl }).then((res) => {
+        setAdminMessages(prev => {
+          if (prev.find(m => m.id === res.id.toString())) {
+            return prev.filter(m => m.id !== tmpId);
+          }
+          return prev.map(m => m.id === tmpId ? {
+            id: res.id.toString(),
+            role: "user",
+            content: res.content,
+            time: new Date(res.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" }),
+            fileUrl: res.fileUrl
+          } : m);
+        });
       }).catch(() => {
         setAdminMessages(prev => [...prev, { id: tmpId + "err", role: "admin", content: "Gửi lỗi.", time: now() }]);
       });
+    }
+  };
+
+  useEffect(() => {
+    if (chatIntent && chatIntent.triggerId > 0) {
+      const isPlainToggle = !chatIntent.mode && !chatIntent.autoSendPrompt && !chatIntent.prefillMessage;
+      if (isPlainToggle) {
+        setChatOpen(prev => !prev);
+      } else {
+        setChatOpen(true);
+      }
+      
+      if (chatIntent.mode) setActiveTab(chatIntent.mode);
+      if (chatIntent.prefillMessage) setInput(chatIntent.prefillMessage);
+      
+      if (chatIntent.autoSendPrompt) {
+        setTimeout(() => {
+          handleSend(chatIntent.autoSendPrompt, undefined, chatIntent.mode || "ai");
+        }, 100);
+      }
+    }
+  }, [chatIntent]);
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files || !e.target.files[0]) return;
+    const file = e.target.files[0];
+    
+    setIsUploadingImage(true);
+    try {
+      const options = {
+        maxSizeMB: 1,
+        maxWidthOrHeight: 1024,
+        useWebWorker: true,
+        fileType: 'image/webp'
+      };
+      const compressedFile = await imageCompression(file, options);
+      const url = await profileApi.uploadFile(compressedFile);
+      handleSend(input.trim(), url);
+      setInput("");
+    } catch (err) {
+      setAdminMessages(prev => [...prev, { id: Date.now().toString(), role: "admin", content: "Lỗi tải ảnh lên, vui lòng thử lại.", time: now() }]);
+    } finally {
+      setIsUploadingImage(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
     }
   };
 
@@ -189,7 +322,7 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
     if (activeTab === "ai") { setAiMessages(INITIAL_AI); }
     else { 
       if (conversationId && user) {
-        getMessagesByConversation(conversationId).then(msgs => {
+        getMessagesByConversation(conversationId, user.id).then(msgs => {
           const mapped: Message[] = msgs.map(m => ({
             id: m.id.toString(),
             role: m.senderId === user.id ? "user" : "admin",
@@ -208,46 +341,7 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
   return (
     <div className="fixed bottom-[76px] md:bottom-6 right-4 z-50 flex flex-col items-end gap-3">
 
-      {/* Pre-chat widget */}
-      {widgetVisible && !chatOpen && (
-        <div className="relative bg-[#406767] rounded-2xl p-6 w-[300px] shadow-2xl flex flex-col gap-4">
-          <button
-            onClick={() => setWidgetVisible(false)}
-            className="absolute top-3 right-3 text-[#bae4e3]/70 hover:text-white transition-colors"
-          >
-            <X size={15} />
-          </button>
-          <div className="flex gap-3 items-start">
-            <div className="shrink-0 mt-0.5 text-[#a5cece]">
-              <svg width="17" height="17" viewBox="0 0 16.9955 16.9923" fill="none">
-                <path d={svgPaths.p12cee600} fill="#A5CECE" />
-              </svg>
-            </div>
-            <p className="text-[#bae4e3] text-[14px] leading-[22px]">
-              Bạn có biết chuyển sang bàn chải tre giúp tiết kiệm{" "}
-              <span className="font-bold underline">1.5kg nhựa</span> mỗi năm không?
-            </p>
-          </div>
-          <div className="bg-[#274f4f] rounded-lg p-4 flex flex-col gap-2">
-            <div className="flex justify-between text-[#bae4e3]/80 text-[11px] uppercase tracking-wider">
-              <span>Tác động CO2</span>
-              <span>Tiết kiệm</span>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-[#bae4e3] text-[14px] font-bold">Bamboo vs Nhựa</span>
-              <span className="text-[#c1eaea] text-[14px] font-bold">-83%</span>
-            </div>
-          </div>
-          <button
-            onClick={handleLearnMore}
-            className="bg-[#c1eaea] text-[#002020] py-2 rounded-sm text-center text-[13px] tracking-[0.1em] uppercase font-medium hover:bg-[#a8dada] transition-colors"
-          >
-            LEARN MORE
-          </button>
-        </div>
-      )}
 
-      {/* Full chat panel */}
       {chatOpen && (
         <div
           className="bg-white rounded-2xl shadow-2xl w-[320px] md:w-[380px] flex flex-col overflow-hidden"
@@ -329,7 +423,12 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
                         border: isUser ? "none" : "1px solid #eef2eb",
                       }}
                     >
-                      {msg.content}
+                      {msg.fileUrl && (
+                        <div className="mb-2">
+                          <img src={msg.fileUrl} alt="attachment" className="max-w-full rounded-lg" style={{ maxHeight: "150px", objectFit: "contain" }} />
+                        </div>
+                      )}
+                      {msg.content !== "[Hình ảnh]" ? (activeTab === "ai" ? renderMarkdown(msg.content) : msg.content) : ""}
                     </div>
                     {msg.time && !isUser && (
                       <span className="text-[10px] text-[#9ca3af] px-1">{msg.time}</span>
@@ -363,18 +462,38 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
           {/* Input */}
           <div className="border-t border-[#eef2eb] bg-white px-4 py-3 shrink-0">
             <div className="flex gap-2 items-center">
+              {activeTab === "admin" && (
+                <>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    ref={fileInputRef}
+                    onChange={handleImageUpload}
+                  />
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isUploadingImage || !conversationId}
+                    className="text-gray-400 hover:text-[#274f4f] transition-colors disabled:opacity-30 p-1"
+                    title="Gửi hình ảnh"
+                  >
+                    {isUploadingImage ? <Loader2 size={18} className="animate-spin" /> : <ImageIcon size={18} />}
+                  </button>
+                </>
+              )}
               <input
                 ref={inputRef}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleSend()}
+                onKeyDown={(e) => e.key === "Enter" && !isUploadingImage && handleSend()}
                 placeholder={activeTab === "ai" ? "Hỏi về carbon, sản phẩm..." : "Nhập tin nhắn hỗ trợ..."}
-                className="flex-1 text-[13px] text-gray-700 outline-none placeholder-gray-400 bg-transparent"
+                className="flex-1 text-[13px] text-gray-700 outline-none placeholder-gray-400 bg-transparent min-w-0"
+                disabled={isUploadingImage}
               />
               <button
-                onClick={handleSend}
-                disabled={!input.trim() || isTyping}
-                className="text-gray-300 hover:text-[#274f4f] transition-colors disabled:opacity-30"
+                onClick={() => handleSend()}
+                disabled={(!input.trim() && !isUploadingImage) || isTyping || isUploadingImage}
+                className={`transition-colors disabled:opacity-30 p-1 ${input.trim() ? "text-[#274f4f]" : "text-gray-300 hover:text-[#274f4f]"}`}
               >
                 <Send size={17} />
               </button>
@@ -391,13 +510,10 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
 
       {/* Floating button — shrinks when scrolled, expands on hover or when chat is open */}
       {(() => {
-        const shrink = scrolled && !chatOpen && !widgetVisible && !hoveringBtn;
+        const shrink = scrolled && !chatOpen && !hoveringBtn;
         return (
           <button
-            onClick={() => {
-              if (chatOpen) { setChatOpen(false); }
-              else { setWidgetVisible((v) => !v); }
-            }}
+            onClick={() => setChatOpen(!chatOpen)}
             onMouseEnter={() => setHoveringBtn(true)}
             onMouseLeave={() => setHoveringBtn(false)}
             aria-label="Chat GreenLife"
@@ -428,7 +544,7 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
                 justifyContent: "center",
               }}
             >
-              {chatOpen || widgetVisible ? (
+              {chatOpen ? (
                 <svg width="18.667" height="18.667" viewBox="0 0 18.6667 18.6667" fill="none">
                   <path d={svgPaths.p2e1eae40} fill="white" />
                 </svg>

--- a/fe/src/app/components/AIChatbot.tsx
+++ b/fe/src/app/components/AIChatbot.tsx
@@ -3,7 +3,7 @@ import { X, RefreshCw, Send, Leaf, Minus, Headphones } from "lucide-react";
 import svgPaths from "../../imports/ProductDetail2/svg-oqupvr7hg1";
 import { chatWithAi, createOrGetConversation, getMessagesByConversation, sendMessage as sendLiveMessage, ChatMessage as ApiChatMessage } from "../../api/chat";
 import { Client } from "@stomp/stompjs";
-import useAuthStore from "../../store/authStore";
+import { useAuthStore } from "../../store/authStore";
 
 interface Message {
   id: string;

--- a/fe/src/app/components/AIChatbot.tsx
+++ b/fe/src/app/components/AIChatbot.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { X, RefreshCw, Send, Leaf, Minus, Headphones } from "lucide-react";
 import svgPaths from "../../imports/ProductDetail2/svg-oqupvr7hg1";
+import { chatWithAi, createOrGetConversation, getMessagesByConversation, ChatMessage as ApiChatMessage } from "../../api/chat";
 
 interface Message {
   id: string;
@@ -21,43 +22,7 @@ Tay cầm tre thu hoạch bền vững từ rừng Moso, lông bàn chải BPA-f
 
 Bạn có muốn tính toán carbon footprint cá nhân không? 🌿`;
 
-const BOT_RESPONSES: Record<string, string> = {
-  default: "Cảm ơn câu hỏi của Anh/Chị! Tôi có thể giúp bạn tìm hiểu thêm về sản phẩm hoặc tác động môi trường. Bạn có câu hỏi gì khác không? 🌿",
-  price: "Bamboo Toothbrush Set (Pack of 4) hiện có giá 149.000 VND. Đây là mức giá rất hợp lý so với giá trị môi trường mà sản phẩm mang lại! 💚",
-  carbon: "Bamboo Toothbrush chỉ thải ra 0.3kg CO2/sản phẩm, trong khi bàn chải nhựa thông thường thải ra đến 1.8kg CO2. Đó là mức giảm 83% lượng khí thải! 🌍",
-  bamboo: "Tre là vật liệu tuyệt vời: kháng khuẩn tự nhiên, phân hủy sinh học 100%, phát triển nhanh không cần thuốc trừ sâu. 🎋",
-  shipping: "Chúng tôi giao hàng toàn quốc trong 2–5 ngày làm việc. Đơn hàng trên 200.000 VND được miễn phí vận chuyển! 🚚",
-  review: "Sản phẩm được đánh giá 4.8/5 từ 127 khách hàng. Hầu hết đều khen ngợi độ bền, thiết kế và tác động tích cực đến môi trường. ⭐",
-  carbon_calc: "Nếu bạn dùng 1 bàn chải/quý = 4 bàn chải/năm.\nVới nhựa: 4 × 1.8kg = 7.2kg CO2/năm\nVới tre: 4 × 0.3kg = 1.2kg CO2/năm\n→ Bạn tiết kiệm 6kg CO2 mỗi năm! 🌱",
-};
-
-function getAIResponse(input: string): string {
-  const lower = input.toLowerCase();
-  if (lower.includes("giá") || lower.includes("bao nhiêu")) return BOT_RESPONSES.price;
-  if (lower.includes("carbon") || lower.includes("co2") || lower.includes("khí thải")) return BOT_RESPONSES.carbon;
-  if (lower.includes("bamboo") || lower.includes("tre")) return BOT_RESPONSES.bamboo;
-  if (lower.includes("giao hàng") || lower.includes("ship")) return BOT_RESPONSES.shipping;
-  if (lower.includes("đánh giá") || lower.includes("review") || lower.includes("sao")) return BOT_RESPONSES.review;
-  if (lower.includes("tính") || lower.includes("footprint") || lower.includes("calc")) return BOT_RESPONSES.carbon_calc;
-  return BOT_RESPONSES.default;
-}
-
-// ─── Admin tab data ───────────────────────────────────────────────────────────
-const ADMIN_RESPONSES: [RegExp, string][] = [
-  [/đơn hàng|order/i, "Anh/Chị cho em mã đơn hàng (ví dụ #GL-9402) để em kiểm tra trạng thái nhanh nhất ạ!"],
-  [/hoàn tiền|refund|đổi trả/i, "Em hiểu ạ! Chính sách đổi trả của GreenLife là 30 ngày kể từ ngày nhận hàng. Anh/Chị có thể cho em biết lý do đổi/trả để em hỗ trợ cụ thể hơn không ạ?"],
-  [/giao hàng|ship|vận chuyển/i, "Thời gian giao hàng tiêu chuẩn là 2–5 ngày làm việc. Đơn hàng trên 200.000 VND miễn phí vận chuyển. Anh/Chị cần kiểm tra đơn hàng cụ thể nào không ạ?"],
-  [/mã giảm giá|voucher|coupon|discount/i, "Hiện tại GreenLife đang có chương trình GREENWEEK giảm 15% cho đơn từ 500.000 VND. Anh/Chị muốn em gửi thêm thông tin về các ưu đãi không ạ?"],
-  [/sản phẩm|hàng|stock|còn/i, "Em sẽ kiểm tra tình trạng kho cho Anh/Chị ngay ạ! Anh/Chị đang quan tâm đến sản phẩm nào ạ?"],
-  [/cảm ơn|thank/i, "Cảm ơn Anh/Chị đã tin tưởng GreenLife! Chúc Anh/Chị một ngày xanh và ý nghĩa 🌿"],
-];
-
-function getAdminResponse(input: string): string {
-  for (const [pattern, reply] of ADMIN_RESPONSES) {
-    if (pattern.test(input)) return reply;
-  }
-  return "Em đã ghi nhận câu hỏi của Anh/Chị. Đội hỗ trợ sẽ phản hồi trong vòng 5–10 phút trong giờ làm việc (8:00–22:00). Anh/Chị có cần hỗ trợ thêm gì không ạ? 😊";
-}
+// Removed mock getAIResponse and getAdminResponse
 
 const now = () => new Date().toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" });
 
@@ -82,19 +47,15 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
   const [input, setInput] = useState("");
   const [isTyping, setIsTyping] = useState(false);
 
-  const [idle, setIdle] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
   const [hoveringBtn, setHoveringBtn] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const handleActivity = () => setIdle(true);
-    window.addEventListener("scroll", handleActivity, { passive: true });
-    window.addEventListener("mousedown", handleActivity);
-    return () => {
-      window.removeEventListener("scroll", handleActivity);
-      window.removeEventListener("mousedown", handleActivity);
-    };
+    const onScroll = () => setScrolled(window.scrollY > 80);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
   useEffect(() => {
@@ -123,7 +84,7 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
     }, 1200);
   };
 
-  const handleSend = () => {
+  const handleSend = async () => {
     if (!input.trim() || isTyping) return;
     const text = input.trim();
     const msgId = Date.now().toString();
@@ -132,18 +93,27 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
       setAiMessages((prev) => [...prev, { id: msgId, role: "user", content: text }]);
       setInput("");
       setIsTyping(true);
-      setTimeout(() => {
+
+      const productIdStr = window.location.pathname.match(/\/product\/(\d+)/)?.[1];
+      const productId = productIdStr ? parseInt(productIdStr) : undefined;
+
+      try {
+        const res = await chatWithAi({ message: text, productId });
+        setAiMessages((prev) => [...prev, { id: msgId + "r", role: "bot", content: res.reply }]);
+      } catch (error) {
+        setAiMessages((prev) => [...prev, { id: msgId + "r", role: "bot", content: "Xin lỗi, AI đang bận. Vui lòng thử lại sau." }]);
+      } finally {
         setIsTyping(false);
-        setAiMessages((prev) => [...prev, { id: msgId + "r", role: "bot", content: getAIResponse(text) }]);
-      }, 800 + Math.random() * 600);
+      }
     } else {
       setAdminMessages((prev) => [...prev, { id: msgId, role: "user", content: text, time: now() }]);
       setInput("");
       setIsTyping(true);
+      // Wait for WS implementation in the future or implement basic WS here
       setTimeout(() => {
         setIsTyping(false);
-        setAdminMessages((prev) => [...prev, { id: msgId + "r", role: "admin", content: getAdminResponse(text), time: now() }]);
-      }, 1200 + Math.random() * 800);
+        setAdminMessages((prev) => [...prev, { id: msgId + "r", role: "admin", content: "Live Chat đang được kết nối...", time: now() }]);
+      }, 1000);
     }
   };
 
@@ -339,9 +309,9 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
         </div>
       )}
 
-      {/* Floating button — shrinks when idle, expands on hover or when chat is open */}
+      {/* Floating button — shrinks when scrolled, expands on hover or when chat is open */}
       {(() => {
-        const shrink = idle && !chatOpen && !widgetVisible && !hoveringBtn;
+        const shrink = scrolled && !chatOpen && !widgetVisible && !hoveringBtn;
         return (
           <button
             onClick={() => {

--- a/fe/src/app/components/AIChatbot.tsx
+++ b/fe/src/app/components/AIChatbot.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 import { X, RefreshCw, Send, Leaf, Minus, Headphones } from "lucide-react";
 import svgPaths from "../../imports/ProductDetail2/svg-oqupvr7hg1";
-import { chatWithAi, createOrGetConversation, getMessagesByConversation, ChatMessage as ApiChatMessage } from "../../api/chat";
+import { chatWithAi, createOrGetConversation, getMessagesByConversation, sendMessage as sendLiveMessage, ChatMessage as ApiChatMessage } from "../../api/chat";
+import { Client } from "@stomp/stompjs";
+import useAuthStore from "../../store/authStore";
 
 interface Message {
   id: string;
@@ -43,9 +45,63 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
   const [activeTab, setActiveTab] = useState<"ai" | "admin">("ai");
 
   const [aiMessages, setAiMessages] = useState<Message[]>(INITIAL_AI);
-  const [adminMessages, setAdminMessages] = useState<Message[]>(INITIAL_ADMIN);
+  const [adminMessages, setAdminMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [isTyping, setIsTyping] = useState(false);
+
+  const { user } = useAuthStore();
+  const [conversationId, setConversationId] = useState<number | null>(null);
+  const stompClientRef = useRef<Client | null>(null);
+
+  // Initialize and connect WS when switching to Admin Tab
+  useEffect(() => {
+    if (activeTab === "admin" && user) {
+      let active = true;
+      createOrGetConversation().then(conv => {
+        if (!active) return;
+        setConversationId(conv.id);
+        getMessagesByConversation(conv.id).then(msgs => {
+          if (!active) return;
+          const mapped: Message[] = msgs.map(m => ({
+            id: m.id.toString(),
+            role: m.senderId === user.id ? "user" : "admin",
+            content: m.content,
+            time: new Date(m.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" })
+          }));
+          setAdminMessages(mapped);
+        });
+
+        const client = new Client({
+          brokerURL: 'ws://localhost:8080/ws',
+          onConnect: () => {
+            client.subscribe(`/topic/conversation/${conv.id}`, (msg) => {
+              const newMsg: ApiChatMessage = JSON.parse(msg.body);
+              setAdminMessages(prev => {
+                if (prev.find(m => m.id === newMsg.id.toString())) return prev;
+                return [...prev, {
+                  id: newMsg.id.toString(),
+                  role: newMsg.senderId === user.id ? "user" : "admin",
+                  content: newMsg.content,
+                  time: new Date(newMsg.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" })
+                }];
+              });
+            });
+          },
+        });
+        client.activate();
+        stompClientRef.current = client;
+      }).catch(() => {
+        if (active) {
+          setAdminMessages([{ id: "err", role: "admin", content: "Lỗi kết nối hoặc bạn chưa đăng nhập.", time: now() }]);
+        }
+      });
+
+      return () => {
+        active = false;
+        stompClientRef.current?.deactivate();
+      };
+    }
+  }, [activeTab, user]);
 
   const [scrolled, setScrolled] = useState(false);
   const [hoveringBtn, setHoveringBtn] = useState(false);
@@ -106,20 +162,44 @@ export function AIChatbot({ openTrigger = 0 }: { openTrigger?: number }) {
         setIsTyping(false);
       }
     } else {
-      setAdminMessages((prev) => [...prev, { id: msgId, role: "user", content: text, time: now() }]);
+      if (!conversationId) {
+        setAdminMessages(prev => [...prev, { id: msgId, role: "admin", content: "Vui lòng đăng nhập để chat trực tiếp.", time: now() }]);
+        return;
+      }
+      
+      const tmpId = Date.now().toString();
+      setAdminMessages((prev) => [...prev, { id: tmpId, role: "user", content: text, time: now() }]);
       setInput("");
-      setIsTyping(true);
-      // Wait for WS implementation in the future or implement basic WS here
-      setTimeout(() => {
-        setIsTyping(false);
-        setAdminMessages((prev) => [...prev, { id: msgId + "r", role: "admin", content: "Live Chat đang được kết nối...", time: now() }]);
-      }, 1000);
+      setIsTyping(false); // real-time so no fake typing wait
+
+      sendLiveMessage({ conversationId, content: text }).then((res) => {
+        setAdminMessages(prev => prev.map(m => m.id === tmpId ? {
+          id: res.id.toString(),
+          role: "user",
+          content: res.content,
+          time: new Date(res.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" })
+        } : m));
+      }).catch(() => {
+        setAdminMessages(prev => [...prev, { id: tmpId + "err", role: "admin", content: "Gửi lỗi.", time: now() }]);
+      });
     }
   };
 
   const handleReset = () => {
     if (activeTab === "ai") { setAiMessages(INITIAL_AI); }
-    else { setAdminMessages(INITIAL_ADMIN); }
+    else { 
+      if (conversationId && user) {
+        getMessagesByConversation(conversationId).then(msgs => {
+          const mapped: Message[] = msgs.map(m => ({
+            id: m.id.toString(),
+            role: m.senderId === user.id ? "user" : "admin",
+            content: m.content,
+            time: new Date(m.createdAt).toLocaleTimeString("vi-VN", { hour: "2-digit", minute: "2-digit" })
+          }));
+          setAdminMessages(mapped);
+        });
+      }
+    }
     setIsTyping(false);
   };
 

--- a/fe/src/app/components/ProfilePage.tsx
+++ b/fe/src/app/components/ProfilePage.tsx
@@ -786,7 +786,7 @@ const ORDER_STATUS_TABS = [
   { key: "CANCELLED", label: "Đã hủy" },
 ];
 
-function OrderHistory({ orders, onOpenChatbot }: { orders: OrderResponse[], onOpenChatbot?: () => void }) {
+function OrderHistory({ orders, onOpenChatbot }: { orders: OrderResponse[], onOpenChatbot?: (opts?: any) => void }) {
   const [reviewTarget, setReviewTarget] = useState<{ orderId: number; productName: string } | null>(null);
   const [statusFilter, setStatusFilter] = useState("ALL");
 
@@ -997,13 +997,16 @@ function OrderHistory({ orders, onOpenChatbot }: { orders: OrderResponse[], onOp
                     </button>
                   )}
                   <button
-                    onClick={() => { if (onOpenChatbot) onOpenChatbot(); }}
+                    onClick={() => {
+                      const itemList = order.orderItems?.map(i => `${i.quantity || 1}x ${i.productName}`).join(", ") || "không có sản phẩm";
+                      if (onOpenChatbot) onOpenChatbot({ mode: "ai", autoSendPrompt: `Phân tích chi tiết lượng phát thải CO2 của đơn hàng #${order.id} (gồm: ${itemList}) giúp tôi.` });
+                    }}
                     className="w-full md:w-auto text-[#25521f] text-[13px] tracking-widest uppercase border border-[#25521f] px-6 py-2.5 rounded-full hover:bg-[#f0f7ee] transition-colors"
                   >
                     Hỏi AI về phát thải đơn hàng
                   </button>
                   <button
-                    onClick={() => { toast.info("Đang phát triển", `Mở chat admin cho đơn ${order.id}`); }}
+                    onClick={() => { if (onOpenChatbot) onOpenChatbot({ mode: "admin", prefillMessage: `Tôi cần hỗ trợ về đơn hàng #${order.id}` }); }}
                     className="w-full md:w-auto text-[#42493e] text-[13px] tracking-widest uppercase border border-[#c2c9bb] px-6 py-2.5 rounded-full bg-white hover:bg-[#fafaf5] transition-colors"
                   >
                     Liên hệ Admin
@@ -1147,7 +1150,7 @@ export function ProfilePage({
   wishlistIds?: number[];
   onWishlist?: (p: Product) => void;
   onAddToCart?: (p: Product) => void;
-  onOpenChatbot?: () => void;
+  onOpenChatbot?: (opts?: any) => void;
 }) {
   const user = useAuthStore(s => s.user);
   const [profile, setProfile] = useState<UserProfileResponse | null>(null);

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,10 +1,10 @@
-﻿## Related Issues
-Closes #54
+## Related Issues
+Closes #55
 
 ## Changes
-**Frontend API** (d761ac6): Added favorites.ts and statistics.ts to connect to BE Wishlist and Carbon Index APIs.
-**Frontend UI** (d761ac6): Updated ImpactPage to fetch dynamic carbon index data and removed redundant mock components.
-**Frontend UI** (d761ac6): Fixed shop page out-of-stock items not updating by refetching products on navigation.
-**Frontend UI** (d761ac6): Fixed shop page sorting by adding 'newest' sort option and casting price/carbonIndex to numeric values.
-**Frontend UI** (348e97e): Added global CSS hover/active pointer cursors.
-**Frontend Routing** (348e97e): Used sessionStorage to persist activePage across reloads.
+**Backend** (2afed0e): Switch Gemini API to `interactions` and manually parse JSON due to model output formatting.
+**Backend** (2afed0e): Inject product catalog into system prompt to provide full environmental context and prevent hallucinations.
+**Frontend** (2afed0e): Implement `renderMarkdown` to support bold, italics, headers, lists, and horizontal rules natively.
+**Frontend** (2afed0e): Fix `activeProductId` state loss on page refresh using `sessionStorage` in `App.tsx`.
+**Frontend** (2afed0e): Enhance chatbot with `ChatbotIntent` support (pre-filled messages, auto-send prompts, specific tab routing).
+**Frontend** (2afed0e): Remove annoying pre-chat promotional widget and make floating bot button toggle chat properly.


### PR DESCRIPTION
## Related Issues
Closes #55

## Changes
**Backend** (2afed0e): Switch Gemini API to `interactions` and manually parse JSON due to model output formatting.
**Backend** (2afed0e): Inject product catalog into system prompt to provide full environmental context and prevent hallucinations.
**Frontend** (2afed0e): Implement `renderMarkdown` to support bold, italics, headers, lists, and horizontal rules natively.
**Frontend** (2afed0e): Fix `activeProductId` state loss on page refresh using `sessionStorage` in `App.tsx`.
**Frontend** (2afed0e): Enhance chatbot with `ChatbotIntent` support (pre-filled messages, auto-send prompts, specific tab routing).
**Frontend** (2afed0e): Remove annoying pre-chat promotional widget and make floating bot button toggle chat properly.
